### PR TITLE
More error detail if the translator gets errors

### DIFF
--- a/matlab2cpp/node/backend.py
+++ b/matlab2cpp/node/backend.py
@@ -529,9 +529,9 @@ See also:
 
         try:
             target = matlab2cpp.rules.__dict__["_"+backend]
-        except KeyError:
-            print "Crash with file: %s. Data type set in .py file could be wrong. " % (str(node.file))
-            raise
+        except KeyError as err:
+            err_str = "\'" + err.message + "\', File: %s. Data type set in .py file could be wrong." % (str(node.file))
+            raise KeyError(err_str)
 
         spesific_name = node.cls + "_" + node.name
 

--- a/matlab2cpp/tree/builder.py
+++ b/matlab2cpp/tree/builder.py
@@ -339,7 +339,7 @@ Example::
         while end < len(self.code) and self.code[end] != "\n":
             end += 1
 
-        out = "line %d in Matlab code:\n" % (self.code.count("\n", 0, cur)+1)
+        out = "File: %s, line %d in Matlab code:\n" % (self.project[-1].name, self.code.count("\n", 0, cur)+1)
         out += self.code[start:end] + "\n" + " "*(cur-start) + "^\n"
         out += "Expected: " + text
         raise SyntaxError(out)


### PR DESCRIPTION
The file name of the Matlab file that causes problems should now be written in the error message.