### PR TITLE
Multiline matlab statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Sphinx::
 
 Argcomplete::
 
-    pip intall argcomplete
+    pip install argcomplete
     activate-global-python-argcomplete
 
 This only works for Bash and would require a restart of terminal emulator.

--- a/matlab2cpp/node/backend.py
+++ b/matlab2cpp/node/backend.py
@@ -614,7 +614,8 @@ See also:
 
     if node.cls in ("Assign", "Assigns", "Statement", "If", "Elif",
                     "For", "Parfor", "While") and node.project.builder.original:
-        value = "// " + node.code + "\n" + value
+        code_tmp = ["// " + line for line in node.code.splitlines()]
+        value = "\n".join(code_tmp) + "\n" + value
         value = value.replace("%", "__percent__")
     node.str = value
 

--- a/matlab2cpp/rules/_expression.py
+++ b/matlab2cpp/rules/_expression.py
@@ -560,10 +560,10 @@ def Elexp(node):
             if(node[0].dim == 0):
                 return "m2cpp::square(" + out + ")"
             else:
-                return "square(" + out + ")"
+                return "arma::square(" + out + ")"
 
     for child in node[1:]:
-        out = "pow(" + str(out) + ", " + str(child) + ")"
+        out = "arma::pow(" + str(out) + ", " + str(child) + ")"
     return out
 
 

--- a/matlab2cpp/tree/findend.py
+++ b/matlab2cpp/tree/findend.py
@@ -61,8 +61,8 @@ Returns:
         elif self.code[k] == "{":
             k = cell(self, k)
 
-        elif self.code[k:k+3] == "...":
-            k = dots(self, k)
+        #elif self.code[k:k+3] == "...":
+        #    k = dots(self, k)
 
         elif self.code[k] == "=":
 

--- a/matlab2cpp/tree/variables.py
+++ b/matlab2cpp/tree/variables.py
@@ -406,7 +406,7 @@ Example:
 
 
 
-    elif self.code[k] == "." and self.code[k+1] not in "*/\\^'":
+    elif self.code[k] == "." and self.code[k+1] not in ".*/\\^'":
 
         k += 1
 


### PR DESCRIPTION
First there is a small typo fix for README.md.

Added arma::, for pow and square.

Most important fix is for matlab statements which are multiline e.g.
a = 4 ...
+ 9

and the -o flag correctly give both lines as comment above the translation e.g.
// a = 4 ...
// + 9
a = 4+9 ;